### PR TITLE
Enable swap file and disk management after re-render

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,8 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+azure:
+  settings_linux:
+      swapfile_size: 10GiB
+  # linux image before running the Docker container for building
+  free_disk_space: True


### PR DESCRIPTION
Previously re-renders were wiping out our changes to the pipelines definition that enabled swap file and disk management. This change causes conda-smithy to include these fixes in the re-render.